### PR TITLE
Enable bsky handle

### DIFF
--- a/.well-known/atproto-did
+++ b/.well-known/atproto-did
@@ -1,0 +1,1 @@
+did:plc:55jhfv3mpnwd746weu5ounvd

--- a/_config.yml
+++ b/_config.yml
@@ -48,3 +48,5 @@ plugins:
 #   - vendor/cache/
 #   - vendor/gems/
 #   - vendor/ruby/
+
+include: [".well-known"]


### PR DESCRIPTION
... following the example of https://dev.to/lucacozzuto/how-to-use-github-to-be-verified-on-bluesky-k3p